### PR TITLE
Switch breakpoint to prevent header overflow

### DIFF
--- a/src/components/TopBar.module.scss
+++ b/src/components/TopBar.module.scss
@@ -83,7 +83,7 @@
   }
 }
 
-@media (min-width: 48rem) {
+@media (min-width: 54rem) {
   .topBar {
     gap: 0 2em;
   }


### PR DESCRIPTION
Fixes this header width overflow at some in-between viewport widths: 
<img width="798" alt="image" src="https://user-images.githubusercontent.com/58062/120246962-36566e80-c248-11eb-91bd-bc903320bcf4.png">
