### PR TITLE
show a total count of icons

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -39,9 +39,9 @@ export default function Home({ categories }: HomeProps) {
     return filteredIcons;
   }, [query, categories]);
 
-  const totalIconCount = categories.flatMap((category) => {
-    return category.icons;
-  }).length;
+  const totalIconCount = categories.reduce((counter, category) => {
+    return counter + category.icons.length;
+  }, 0);
 
   return (
     <div className="container">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -88,7 +88,7 @@ export default function Home({ categories }: HomeProps) {
           <input
             type="text"
             className={styles.filterBoxInput}
-            placeholder={`Search ${totalIconCount} Icons...`}
+            placeholder={`Search ${totalIconCount} Icons…`}
             onChange={(e) => setQuery(e.target.value)}
           />
         </label>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -39,6 +39,10 @@ export default function Home({ categories }: HomeProps) {
     return filteredIcons;
   }, [query, categories]);
 
+  const totalIconCount = categories.flatMap((category) => {
+    return category.icons;
+  }).length;
+
   return (
     <div className="container">
       <Head>
@@ -84,7 +88,7 @@ export default function Home({ categories }: HomeProps) {
           <input
             type="text"
             className={styles.filterBoxInput}
-            placeholder="Search for icons..."
+            placeholder={`Search ${totalIconCount} Icons...`}
             onChange={(e) => setQuery(e.target.value)}
           />
         </label>


### PR DESCRIPTION
fixes https://github.com/resolvetosavelives/healthicons/issues/41

To test, just open the site, and look at the search box. It should have a count of all of the icons.

I'm presuming it's all of the base icons, and not 2x that (fill + outline versions).