### PR TITLE
Bump icon labels to two lines rather than truncating at one

### DIFF
--- a/src/components/IconTile.module.scss
+++ b/src/components/IconTile.module.scss
@@ -53,10 +53,14 @@
   font-size: 0.8rem;
   color: rgba(134,134,155,0.6);
   width: 100%;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   text-align: center;
+  height: 30px;
+  word-break: break-all;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 @media (min-width: 48rem) {


### PR DESCRIPTION
Proposing to allow icon labels to occupy two lines rather than truncating at one. Useful for cases like below where the end of the label is what differentiates it from others.

<img width="1267" alt="Screen Shot 2021-06-01 at 9 09 01 PM" src="https://user-images.githubusercontent.com/47726286/120420405-ecde5000-c329-11eb-8b6d-b5b9f6c31a20.png">
<img width="1258" alt="Screen Shot 2021-06-01 at 9 09 14 PM" src="https://user-images.githubusercontent.com/47726286/120420419-ef40aa00-c329-11eb-8859-74a27767cef6.png">
