### PR TITLE
Remove category headings from filtered results

### DIFF
--- a/src/components/IconGrid.tsx
+++ b/src/components/IconGrid.tsx
@@ -1,0 +1,41 @@
+import { IconTile } from './IconTile';
+import { Icon } from '../lib/icons';
+import { SearchStyle } from '../store/search';
+import { ModalIcon } from './LandingPage';
+import styles from '../pages/index.module.scss';
+import { Dispatch, SetStateAction } from 'react';
+import { useRouter } from 'next/router';
+
+interface IconGridProps {
+  icons: Icon[];
+  style: SearchStyle;
+  setModalIcon: Dispatch<SetStateAction<ModalIcon>>;
+}
+
+export default function IconGrid({
+  icons,
+  style,
+  setModalIcon
+}: IconGridProps) {
+  const router = useRouter();
+  return (
+    <div className={styles.iconGrid}>
+      {icons.map((icon, iconIndex) => (
+        <IconTile
+          key={iconIndex}
+          icon={icon}
+          iconStyle={style}
+          visible={true}
+          onClick={(iconType: string) => {
+            // uses the "as" property instead of the "url" to keep the route from changing which causes all of the icons to re-render each time. See the useEffect() above that captures the back/forward buttons to handle the URL changes
+            router.push('/', `/icon/${iconType}/${icon.category}/${icon.id}`, {
+              shallow: true,
+              scroll: false
+            });
+            setModalIcon({ icon, iconType });
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/IconGrid.tsx
+++ b/src/components/IconGrid.tsx
@@ -27,7 +27,7 @@ export default function IconGrid({
           iconStyle={style}
           visible={true}
           onClick={(iconType: string) => {
-            // uses the "as" property instead of the "url" to keep the route from changing which causes all of the icons to re-render each time. See the useEffect() above that captures the back/forward buttons to handle the URL changes
+            // uses the "as" property instead of the "url" to keep the route from changing which causes all of the icons to re-render each time. See the useEffect() in LandingPage that captures the back/forward buttons to handle the URL changes
             router.push('/', `/icon/${iconType}/${icon.category}/${icon.id}`, {
               shallow: true,
               scroll: false

--- a/src/components/IconTile.tsx
+++ b/src/components/IconTile.tsx
@@ -3,11 +3,12 @@ import { LazyLoadImage } from 'react-lazy-load-image-component';
 import 'react-lazy-load-image-component/src/effects/opacity.css';
 import styles from './IconTile.module.scss';
 import { Icon } from '../lib/icons';
+import { SearchStyle } from '../store/search';
 
 interface IconTileProps {
   icon: Icon;
   visible: boolean;
-  iconStyle: 'all' | 'filled' | 'outline';
+  iconStyle: SearchStyle;
   onClick: (type: string) => void;
 }
 

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -19,13 +19,17 @@ interface ModalIcon {
   iconType: string;
 }
 
-interface IconGridProps {
+interface LandingPageProps {
   categories: Category[];
   icon?: Icon;
   style?: 'outline' | 'filled';
 }
 
-export default function IconGrid({ icon, style, categories }: IconGridProps) {
+export default function LandingPage({
+  icon,
+  style,
+  categories
+}: LandingPageProps) {
   const dispatch = useDispatch();
   const searchKeywordsValue = useSelector(
     (state: RootState) => state.search.keywords

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -8,13 +8,13 @@ import { searchKeywords } from '../lib/searchKeywords';
 import { TopBar } from './TopBar';
 import { CategoryHeading } from './CategoryHeading';
 import { CategoryDropdown } from './CategoryDropdown';
-import { IconTile } from './IconTile';
+import IconGrid from './IconGrid';
 import { IconTileModal } from './IconTileModal';
 import styles from '../pages/index.module.scss';
 
 import { Category, Icon } from '../lib/icons';
 
-interface ModalIcon {
+export interface ModalIcon {
   icon: Icon;
   iconType: string;
 }
@@ -161,38 +161,25 @@ export default function LandingPage({
             </div>
           </div>
         </div>
-
-        {categories.map((c, categoryIndex) => (
-          <div key={categoryIndex}>
-            {(!isFiltered ||
-              c.icons.some((i) => {
-                return iconsToRender.includes(i);
-              })) && <CategoryHeading>{c.title}</CategoryHeading>}
-            <div className={styles.iconGrid}>
-              {c.icons.map((i, iconIndex) => (
-                <IconTile
-                  key={iconIndex}
-                  icon={i}
-                  iconStyle={searchStyleValue}
-                  visible={!isFiltered || iconsToRender.includes(i)}
-                  onClick={(iconType: string) => {
-                    // uses the "as" property instead of the "url" to keep the route from changing which causes all of the icons to re-render each time. See the useEffect() above that captures the back/forward buttons to handle the URL changes
-                    router.push(
-                      '/',
-                      `/icon/${iconType}/${i.category}/${i.id}`,
-                      {
-                        shallow: true,
-                        scroll: false
-                      }
-                    );
-
-                    setModalIcon({ icon: i, iconType });
-                  }}
-                />
-              ))}
+        {isFiltered ? (
+          <IconGrid
+            icons={iconsToRender}
+            setModalIcon={setModalIcon}
+            style={searchStyleValue}
+          />
+        ) : (
+          categories.map((c, categoryIndex) => (
+            <div key={categoryIndex}>
+              <CategoryHeading>{c.title}</CategoryHeading>
+              <IconGrid
+                icons={c.icons}
+                setModalIcon={setModalIcon}
+                style={searchStyleValue}
+                key={c.title}
+              />
             </div>
-          </div>
-        ))}
+          ))
+        )}
         {modalIcon && (
           <IconTileModal
             icon={modalIcon.icon}

--- a/src/pages/icon/[style]/[category]/[icon].tsx
+++ b/src/pages/icon/[style]/[category]/[icon].tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import HeadTags from '../../../../components/HeadTags';
-import IconGrid from '../../../../components/IconGrid';
+import LandingPage from '../../../../components/LandingPage';
 
 import { getCategoriesAndIcons, Category } from '../../../../lib/icons';
 
@@ -30,7 +30,7 @@ export default function IconPage({
         path={router.asPath}
         image={`og-icon-images/${iconObj.category}/${iconObj.id}.png`}
       />
-      <IconGrid categories={categories} icon={iconObj} style={style} />
+      <LandingPage categories={categories} icon={iconObj} style={style} />
     </>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import HeadTags from '../components/HeadTags';
-import IconGrid from '../components/IconGrid';
+import LandingPage from '../components/LandingPage';
 import { GetStaticProps } from 'next';
 import { getCategoriesAndIcons, Category } from '../lib/icons';
 
@@ -11,7 +11,7 @@ export default function Home({ categories }: HomeProps) {
   return (
     <>
       <HeadTags />
-      <IconGrid categories={categories} />
+      <LandingPage categories={categories} />
     </>
   );
 }

--- a/src/store/search.tsx
+++ b/src/store/search.tsx
@@ -1,8 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+export type SearchStyle = 'outline' | 'filled' | 'all';
+
 export interface SearchState {
   keywords: string;
-  style: 'outline' | 'filled' | 'all';
+  style: SearchStyle;
   category: string;
 }
 
@@ -19,7 +21,7 @@ export const searchSlice = createSlice({
     setKeywords: (state, action: PayloadAction<string>) => {
       state.keywords = action.payload;
     },
-    setStyle: (state, action: PayloadAction<'outline' | 'filled' | 'all'>) => {
+    setStyle: (state, action: PayloadAction<SearchStyle>) => {
       state.style = action.payload;
     },
     setCategory: (state, action: PayloadAction<string>) => {


### PR DESCRIPTION
### Changes
- Renamed the original IconGrid component to LandingPage, since that's what it actually was (it had way more in it than the actual icon grid).
- Created a new IconGrid component with just the icon grid code.
- Removed headings from filtered results
- Kept using individual icon grid per category for unfiltered results (so they look exactly like they used to), but used a single icon grid for filtered ones (so they wrap nicely).

### Testing
- Make sure that the page looks just like it did for unfiltered icons (no search keywords, no category selected in the dropdown), even if you toggle between icon styles.
- Search for a keyword. The category headings should disappear, and the icons should fill the grid continuously, without being broken up by category.
- Select a category from the dropdown. The category heading should not show up there either.
- Open the page with a modal link. Make sure it still works/looks the same as before.