### PR TITLE
Make icons publishable to NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,16 @@ The project is hosted by the public health not-for-profit [Resolve to Save Lives
 
 ### Accessing Icons
 
-Icons are available in several formats and in a few ways:
+Icons are available in several formats:
 
 - All icons are produced in "outline", "filled", and "negative" styles
 - Each icon is available in SVG and in PNG (48px and 96px)
-- Icons can be downloaded individually via [our website](https://healthicons.org), downloaded together in [a ZIP file](https://healthicons.org/icons.zip), or accessed under the [public/icons](https://github.com/resolvetosavelives/healthicons/tree/main/public/icons) folder in this GitHub project.
+
+Icons can be downloaded in a few ways:
+
+- Individually from [our website](https://healthicons.org)
+- Together as [a ZIP file](https://healthicons.org/icons.zip)
+- Via [NPM](https://www.npmjs.com/package/healthicons): `npm i healthicons` or `yarn add healthicons`
 
 ### Icon Requests
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "health-icons",
+  "name": "healthicons",
   "version": "0.1.0",
   "license": "MIT",
   "scripts": {
@@ -74,5 +74,6 @@
     "suiteNameTemplate": "{filename}",
     "classNameTemplate": "{title}",
     "titleTemplate": "{title}"
-  }
+  },
+  "files": ["public/icons"]
 }


### PR DESCRIPTION
Closes #152

This PR makes the icons publishable to the NPM registry.

At a minimum, it does the following:

- Add `package.json#files` to specify the folder to include to publish (`public/icons`)
- Update the `README` to include NPM as a download source

To test this locally, you can run `yarn pack` to simulate how the library will be packaged when publishing.

Unzipping the tarball should produce the following structure:

```
LICENSE
package.json
public/icons/*
README.md
```

## Recommendations

1. I would *highly* recommend a [CHANGELOG.md](https://keepachangelog.com/en/1.1.0/) be created to document changes to icons for subsequent publishes. NPM uses [semantic versioning](https://semver.org/).
2. I would recommend including some `package.json#keywords` as additional metadata.