### PR TITLE
Make icons publishable to NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,17 @@ The project is hosted by the public health not-for-profit [Resolve to Save Lives
 
 ### Accessing Icons
 
-Icons are available in several formats and in a few ways:
+Icons are available in several formats:
 
 - All icons are produced in "outline", "filled", and "negative" styles
 - Each icon is available in SVG and in PNG (48px and 96px)
-- Icons can be downloaded individually via [our website](https://healthicons.org), downloaded together in [a ZIP file](https://healthicons.org/icons.zip), or accessed under the [public/icons](https://github.com/resolvetosavelives/healthicons/tree/main/public/icons) folder in this GitHub project.
+
+
+Icons can be downloaded in a few ways:
+
+- Individually from [our website](https://healthicons.org)
+- Together as [a ZIP file](https://healthicons.org/icons.zip)
+- Via [NPM](https://www.npmjs.com/package/healthicons): `npm i healthicons` or `yarn add healthicons`
 
 ### Icon Requests
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "health-icons",
-  "version": "0.1.0",
+  "name": "healthicons",
+  "version": "1.0.1",
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
@@ -76,5 +76,6 @@
     "suiteNameTemplate": "{filename}",
     "classNameTemplate": "{title}",
     "titleTemplate": "{title}"
-  }
+  },
+  "files": ["public/icons"]
 }


### PR DESCRIPTION
This is just a rebased version of https://github.com/resolvetosavelives/healthicons/pull/185