### PR TITLE
feat: add copy SVG to clipboard feature in icon modal

### DIFF
--- a/src/components/IconTileModal.tsx
+++ b/src/components/IconTileModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import styles from './IconTileModal.module.scss';
 import ReactModal from 'react-modal';
 import { useRouter } from 'next/navigation';
@@ -19,6 +19,8 @@ export function IconTileModal(props: IconTileModalProps) {
   const router = useRouter();
   const dispatch = useDispatch();
 
+  const [copied, setCopied] = useState(false);
+
   const currentIndex = props.allIcons.map((i) => i.id).indexOf(props.icon.id);
   const nextIcon =
     currentIndex < props.allIcons.length - 1
@@ -30,6 +32,20 @@ export function IconTileModal(props: IconTileModalProps) {
   const handleTagClick = (tag: string) => {
     dispatch(setKeywords(tag));
     props.onClose();
+  };
+
+  const handleCopySVG = async () => {
+    try {
+      const res = await fetch(
+        `/icons/svg/${props.iconType}/${props.icon.category}/${props.icon.id}.svg`
+      );
+      const svgText = await res.text();
+      await navigator.clipboard.writeText(svgText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy SVG', error);
+    }
   };
 
   useEffect(() => {
@@ -52,7 +68,6 @@ export function IconTileModal(props: IconTileModalProps) {
     };
     document.addEventListener('keydown', keyDownHandler);
 
-    // clean up
     return () => {
       document.removeEventListener('keydown', keyDownHandler);
     };
@@ -129,7 +144,11 @@ export function IconTileModal(props: IconTileModalProps) {
             >
               <span>96px PNG</span>
             </a>
+            <button onClick={handleCopySVG} className={styles.modalButton}>
+              <span>{copied ? 'Copied!' : 'Copy SVG to Clipboard'}</span>
+            </button>
           </div>
+
           {props.icon.formats.includes('24px') && (
             <>
               <img


### PR DESCRIPTION
Feature: Copy SVG to Clipboard in Icon Modal
This pull request adds a "Copy SVG to Clipboard" button in the icon modal. It allows users to copy the raw SVG markup of an icon directly, similar to features found in other icon libraries.

What’s added:
A new button labeled “Copy SVG to Clipboard” in the modal
Logic to fetch the SVG content using fetch()
Uses navigator.clipboard.writeText() to copy the content
Visual feedback with the text changing to “Copied!” after successful copy

Why this matters:
This improves usability for developers who want to quickly use the inline SVG in their code without downloading and opening files.

Testing:
Tested locally. The modal displays the button, and clicking it successfully copies the SVG markup to the clipboard.

