### PR TITLE
feat: enhance searchKeywords with partial match support and add test …

### DIFF
--- a/src/lib/searchKeywords.test.ts
+++ b/src/lib/searchKeywords.test.ts
@@ -24,4 +24,21 @@ describe('searchKeywords', () => {
   test('NO match multiple search terms', () => {
     expect(searchKeywords('brown bear', 'quick brown fox')).toBe(false);
   });
+
+  // New tests for improved functionality
+  test('empty search returns true', () => {
+    expect(searchKeywords('', 'quick brown fox')).toBe(true);
+  });
+
+  test('whitespace-only search returns true', () => {
+    expect(searchKeywords('   ', 'quick brown fox')).toBe(true);
+  });
+
+  test('partial word match without word boundary', () => {
+    expect(searchKeywords('ow', 'quick brown fox')).toBe(true);
+  });
+
+  test('multiple partial matches', () => {
+    expect(searchKeywords('ick ow', 'quick brown fox')).toBe(true);
+  });
 });

--- a/src/lib/searchKeywords.tsx
+++ b/src/lib/searchKeywords.tsx
@@ -1,6 +1,20 @@
 export function searchKeywords(search: string, keywords: string): boolean {
-  return new RegExp(
-    '(?=.*?\\b' + search.split(' ').join(')(?=.*?\\b') + ').*',
-    'i'
-  ).test(keywords);
+  // If search is empty, return true to show all results
+  if (!search || search.trim() === '') {
+    return true;
+  }
+
+  // Split search terms and filter out empty strings
+  const searchTerms = search.trim().split(/\s+/).filter(term => term.length > 0);
+  
+  // If no valid search terms after filtering, return true
+  if (searchTerms.length === 0) {
+    return true;
+  }
+
+  // Create a regex pattern that matches all search terms in any order
+  // The \b word boundary is removed to better support partial matches
+  const pattern = '(?=.*?' + searchTerms.join(')(?=.*?') + ').*';
+  
+  return new RegExp(pattern, 'i').test(keywords);
 }


### PR DESCRIPTION
## Enhanced Search Functionality

### Summary
Improved icon search relevance and usability by:
- Adding flexible partial word matching without strict word boundaries
- Handling empty/whitespace searches to show all results
- Increasing test coverage for edge cases

### Changes
- Modified `searchKeywords.tsx` to:
  - Return `true` for empty/whitespace searches (show all icons)
  - Support partial matches anywhere in keywords
  - Remove word boundary restrictions (`\b` in regex)
  
- Updated `searchKeywords.test.ts` with 4 new test cases covering:
  - Empty search behavior
  - Whitespace-only queries 
  - Partial substring matches
  - Combined partial term searches

### User Impact
These changes make the icon search:
- More forgiving for partial matches (e.g. "nex" finds "nexus")
- More intuitive when clearing searches (shows full list)
- Better at handling complex queries like "health card" → matches "health-insurance-card"

Particularly benefits users searching for Nexus Framework-related icons by allowing flexible term combinations without requiring exact word matches.